### PR TITLE
prevents and error when creating the owner label on gcp if var.owner defined as email address

### DIFF
--- a/gcp.tf
+++ b/gcp.tf
@@ -8,7 +8,7 @@ resource "google_dns_managed_zone" "gcp_sub_zone" {
   description = "Managed by Terraform, Delegated Sub Zone for GCP for  ${var.namespace}"
   labels = {
     name       = var.namespace
-    owner      = var.owner
+    owner      = replace(var.owner, "/@|\\./", "-")
     created-by = var.created-by
   }
 }


### PR DESCRIPTION
Fixes issue #3 

This prevents and error when creating the owner label on `google_dns_managed_zone` if the `owner` var is set to an email address (which is stated as required in the new aws account guidance email).
- Changes occurrences of `@` and `.` in `var.owner` when assigning it as a label to the gcp zone.
- Does not protect against other invalid characters, although it's expected than an email address or username are the most likely values.
