### PR TITLE
Cleanup outputs and simplify calling module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
 terraform {
   required_version = ">= 0.12.4"
+  required_providers {
+    aws     = ">= 2.46"
+    google  = ">= 3.5"
+    azurerm = ">= 1.42"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,3 @@
-# AWS General Configuration
-provider "aws" {
-  version = "~> 2.46.0"
-  region  = var.aws_region
-}
-
-# GCP General Configuration
-provider "google" {
-  version = "~> 3.5"
-  project = var.gcp_project
-  region  = var.gcp_region
-}
-
-# Azure General Configuration
-provider "azurerm" {
-  version = "~>1.42.0"
+terraform {
+  required_version = ">= 0.12.4"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,27 +1,27 @@
 output "aws_sub_zone_id" {
-  value = aws_route53_zone.aws_sub_zone.*.zone_id
+  value = var.create_aws_dns_zone ? aws_route53_zone.aws_sub_zone[0].zone_id : ""
 }
 
 output "aws_sub_zone_nameservers" {
-  value = aws_route53_zone.aws_sub_zone.*.name_servers
+  value = var.create_aws_dns_zone ? aws_route53_zone.aws_sub_zone[0].name_servers : []
 }
 
 output "azure_sub_zone_name" {
-  value = azurerm_dns_zone.azure_sub_zone.*.id
+  value = var.create_azure_dns_zone ? azurerm_dns_zone.azure_sub_zone[0].id : ""
 }
 
 output "azure_sub_zone_nameservers" {
-  value = azurerm_dns_zone.azure_sub_zone.*.name_servers
+  value = var.create_azure_dns_zone ? azurerm_dns_zone.azure_sub_zone[0].name_servers : []
 }
 
 output "azure_dns_resourcegroup" {
-  value = azurerm_resource_group.dns_resource_group.*.name
+  value = var.create_azure_dns_zone ? azurerm_resource_group.dns_resource_group[0].name : ""
 }
 
 output "gcp_dns_zone_name" {
-  value = google_dns_managed_zone.gcp_sub_zone.*.name
+  value = var.create_gcp_dns_zone ? google_dns_managed_zone.gcp_sub_zone[0].name : ""
 }
 
 output "gcp_dns_zone_nameservers" {
-  value = google_dns_managed_zone.gcp_sub_zone.*.name_servers
+  value = var.create_gcp_dns_zone ? google_dns_managed_zone.gcp_sub_zone[0].name_servers : []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,11 +24,6 @@ variable "create_aws_dns_zone" {
   default     = "false"
 }
 
-variable "aws_region" {
-  description = "The region to create resources."
-  default     = "eu-west-2"
-}
-
 # Azure
 
 variable "create_azure_dns_zone" {
@@ -52,9 +47,4 @@ variable "create_gcp_dns_zone" {
 
 variable "gcp_project" {
   description = "GCP project name"
-}
-
-variable "gcp_region" {
-  description = "GCP region, e.g. us-east1"
-  default     = "europe-west3"
 }


### PR DESCRIPTION
This PR makes two changes:

- simplifies output values by removing extra list element around each output
  - outputs for `nameserver` values now returned as single-level lists
  - non-list outputs now returned as strings
  - simplifies retrieval of values from other workspaces via `terraform_remote_state`
- replaces provider declarations with `required_providers` block
  - follows recommended to [keep explicit provider configurations only in the root module](https://www.terraform.io/docs/configuration/modules.html#providers-within-modules)
  - allows module consumers to upgrade to newer provider versions without altering the module
  - eliminates need to pass `aws_region` and `gcp_region` as module inputs and declare as variables

(edited for most recent commit)