### PR TITLE
Add Azure name output in addition to ID

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,14 @@ output "aws_sub_zone_nameservers" {
   value = var.create_aws_dns_zone ? aws_route53_zone.aws_sub_zone[0].name_servers : []
 }
 
+output "azure_sub_zone_id" {
+  description = "The Azure Sub Zone ID"
+  value = var.create_azure_dns_zone ? azurerm_dns_zone.azure_sub_zone[0].id : ""
+}
+
 output "azure_sub_zone_name" {
   description = "The Azure Sub Zone Name"
-  value = var.create_azure_dns_zone ? azurerm_dns_zone.azure_sub_zone[0].id : ""
+  value = var.create_azure_dns_zone ? azurerm_dns_zone.azure_sub_zone[0].name : ""
 }
 
 output "azure_sub_zone_nameservers" {


### PR DESCRIPTION
He Lance, was trying to use the azure name output to create some dns records but that one actually exports the resource id which isn't that useful to create records with. We actually need the name (not the ID) to create a a record for example. This does some renaming and adds an additional output to export both the name and the id of the azure zone. BTW checked on github and nobody seems to be using this output at the moment so should be save to merge.